### PR TITLE
Speicherung der Lagennummer in `Layer`

### DIFF
--- a/AdditionalOptimizers/src/de/elamx/clt/optimization/additionaloptimizers/branchandbound/BranchAndBoundOptimizer.java
+++ b/AdditionalOptimizers/src/de/elamx/clt/optimization/additionaloptimizers/branchandbound/BranchAndBoundOptimizer.java
@@ -28,8 +28,8 @@ package de.elamx.clt.optimization.additionaloptimizers.branchandbound;
 import de.elamx.clt.optimization.OptimizationInput;
 import de.elamx.clt.optimization.Optimizer;
 import de.elamx.clt.optimization.additionaloptimizers.DummyBundle;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.Laminat;
-import de.elamx.laminate.Layer;
 import de.elamx.laminate.optimization.MinimalReserveFactorCalculator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,7 +57,7 @@ public class BranchAndBoundOptimizer extends Optimizer{
         double[] angles = input.getAngles();
         ArrayList<MinimalReserveFactorCalculator> calculators = input.getCalculators();
 
-        Layer baseLayer = new Layer("", NbBundle.getMessage(DummyBundle.class, "Optimized_Layer") + " " + atomicLayerCounter.incrementAndGet(), input.getMaterial(), 0.0, input.getThickness(), input.getCriterion());
+        DataLayer baseLayer = new DataLayer("", NbBundle.getMessage(DummyBundle.class, "Optimized_Layer") + " " + atomicLayerCounter.incrementAndGet(), input.getMaterial(), 0.0, input.getThickness(), input.getCriterion());
 
         Laminat laminat = new Laminat(UUID.randomUUID().toString(), NbBundle.getMessage(DummyBundle.class, "Optimized_Laminate") + " " + atomicLaminateCounter.incrementAndGet(), false);
 
@@ -132,11 +132,11 @@ public class BranchAndBoundOptimizer extends Optimizer{
         return bestLam;
     }
     
-    private Laminat[] createSubLaminates(Laminat laminate, Layer baseLayer, double[] angles){
+    private Laminat[] createSubLaminates(Laminat laminate, DataLayer baseLayer, double[] angles){
         Laminat[] newLaminates = new Laminat[angles.length];
         for(int ii = 0; ii < angles.length; ii++){
             newLaminates[ii] = laminate.getCopyWithoutListener(false);
-            Layer newLayer = baseLayer.getCopyWithoutListeners(angles[ii]);
+            DataLayer newLayer = baseLayer.getCopyWithoutListeners(angles[ii]);
             newLaminates[ii].addLayer(newLayer);
         }
         return newLaminates;

--- a/AdditionalOptimizers/src/de/elamx/clt/optimization/additionaloptimizers/todoroki/TodorokiOptimizer.java
+++ b/AdditionalOptimizers/src/de/elamx/clt/optimization/additionaloptimizers/todoroki/TodorokiOptimizer.java
@@ -29,9 +29,9 @@ import de.elamx.clt.optimization.OptimizationInput;
 import de.elamx.clt.optimization.Optimizer;
 import de.elamx.clt.optimization.additionaloptimizers.DummyBundle;
 import de.elamx.clt.optimization.sda.SequentialDecisionApproach;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.DefaultMaterial;
 import de.elamx.laminate.Laminat;
-import de.elamx.laminate.Layer;
 import de.elamx.laminate.addFailureCriteria.MaxStress;
 import de.elamx.laminate.failure.Criterion;
 import de.elamx.laminate.optimization.MinimalReserveFactorCalculator;
@@ -66,9 +66,9 @@ public class TodorokiOptimizer extends Optimizer{
         double[] angles = input.getAngles();
         ArrayList<MinimalReserveFactorCalculator> calculators = input.getCalculators();
 
-        Layer baseLayer = new Layer("", NbBundle.getMessage(DummyBundle.class, "Optimized_Layer") + " " + atomicLayerCounter.incrementAndGet(), input.getMaterial(), 0.0, input.getThickness(), input.getCriterion());
+        DataLayer baseLayer = new DataLayer("", NbBundle.getMessage(DummyBundle.class, "Optimized_Layer") + " " + atomicLayerCounter.incrementAndGet(), input.getMaterial(), 0.0, input.getThickness(), input.getCriterion());
         
-        Layer superLayer = getSuperlayer();
+        DataLayer superLayer = getSuperlayer();
         
         Laminat laminat = new Laminat(UUID.randomUUID().toString(), NbBundle.getMessage(DummyBundle.class, "Optimized_Laminate") + " " + atomicLaminateCounter.incrementAndGet(), false);
 
@@ -204,11 +204,11 @@ public class TodorokiOptimizer extends Optimizer{
         return bestIndiv.laminat;
     }
     
-    private Individuum[] createSubLaminates(Individuum indiv, Layer baseLayer, double[] angles){
+    private Individuum[] createSubLaminates(Individuum indiv, DataLayer baseLayer, double[] angles){
         Individuum[] newIndivs = new Individuum[angles.length];
         for(int ii = 0; ii < angles.length; ii++){
             Laminat lam = indiv.getLaminat().getCopyWithoutListener(false);
-            Layer newLayer = baseLayer.getCopyWithoutListeners(baseLayer.getAngle());
+            DataLayer newLayer = baseLayer.getCopyWithoutListeners(baseLayer.getAngle());
             newLayer.setAngle(angles[ii]);
             lam.setLayer(indiv.getOutestSuperLayerPosition(), newLayer);
             newIndivs[ii] = new Individuum(lam,indiv.getOutestSuperLayerPosition()+1);
@@ -226,7 +226,7 @@ public class TodorokiOptimizer extends Optimizer{
         return true;
     }
     
-    private Layer getSuperlayer(){
+    private DataLayer getSuperlayer(){
         double EPar = input.getMaterial().getEpar();
         double nue  = 0.0;
         double G    = EPar/(2.0*(1.0+nue));
@@ -253,7 +253,7 @@ public class TodorokiOptimizer extends Optimizer{
                 }
             }
         
-        return new Layer("", "Superlayer", superMaterial,  0.0, input.getThickness(), criterion);
+        return new DataLayer("", "Superlayer", superMaterial,  0.0, input.getThickness(), criterion);
     }
     
     private class Individuum{

--- a/Classical_Laminated_Plate_Theory/src/de/elamx/clt/CLT_Laminate.java
+++ b/Classical_Laminated_Plate_Theory/src/de/elamx/clt/CLT_Laminate.java
@@ -176,7 +176,7 @@ public class CLT_Laminate extends CLT_Object{
     private CLT_Layer[] initCLTLayers(){
         layers = new CLT_Layer[laminat.getNumberofLayers()];
         
-        ArrayList<Layer> orig_layers = laminat.getLayers();
+        ArrayList<Layer> orig_layers = laminat.getAllLayers();
         
         CLT_Layer tempLayer;
         int ind = 0;
@@ -185,16 +185,6 @@ public class CLT_Laminate extends CLT_Object{
                 layers[ind++] = new CLT_Layer(l);
             }else{
                 layers[ind++] = tempLayer;
-            }
-        }
-        
-        if (laminat.isSymmetric()){
-            int start = orig_layers.size()-1;
-            if (laminat.isWithMiddleLayer()) {
-                start--;
-            }
-            for (int ii = start; ii >= 0; ii--){
-                layers[ind++] = new CLT_Layer(orig_layers.get(ii));
             }
         }
 

--- a/Classical_Laminated_Plate_Theory/test/unit/src/de/elamx/clt/CLT_CalculatorTest.java
+++ b/Classical_Laminated_Plate_Theory/test/unit/src/de/elamx/clt/CLT_CalculatorTest.java
@@ -25,9 +25,9 @@
  */
 package de.elamx.clt;
 
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.DefaultMaterial;
 import de.elamx.laminate.Laminat;
-import de.elamx.laminate.Layer;
 import de.elamx.laminate.StressStrainState;
 import de.elamx.laminate.failure.Puck;
 import java.util.ArrayList;
@@ -57,12 +57,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -117,12 +117,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -278,12 +278,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -339,12 +339,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -500,12 +500,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -561,12 +561,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -722,12 +722,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -783,12 +783,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -944,12 +944,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -1005,12 +1005,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -1166,12 +1166,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -1227,12 +1227,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -1388,12 +1388,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -1449,12 +1449,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -1610,12 +1610,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -1671,12 +1671,12 @@ public class CLT_CalculatorTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 

--- a/Classical_Laminated_Plate_Theory/test/unit/src/de/elamx/clt/CLT_LayerTest.java
+++ b/Classical_Laminated_Plate_Theory/test/unit/src/de/elamx/clt/CLT_LayerTest.java
@@ -25,10 +25,9 @@
  */
 package de.elamx.clt;
 
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.DefaultMaterial;
 import de.elamx.laminate.Laminat;
-import de.elamx.laminate.Layer;
-import de.elamx.laminate.StressStrainState;
 import de.elamx.laminate.failure.Puck;
 import java.util.ArrayList;
 import java.util.List;
@@ -58,12 +57,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -101,12 +100,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -180,12 +179,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -219,12 +218,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -258,12 +257,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -297,12 +296,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -367,12 +366,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 0.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 70.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
         lam.setInvertZ(true);
@@ -437,12 +436,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -476,12 +475,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -515,12 +514,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 
@@ -554,12 +553,12 @@ public class CLT_LayerTest {
         mat.putAdditionalValue(Puck.A0, 0.5);
         mat.putAdditionalValue(Puck.LAMBDA_MIN, 0.5);
 
-        List<Layer> layers = new ArrayList<>();
+        List<DataLayer> layers = new ArrayList<>();
 
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
-        layers.add(new Layer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer1", mat, 70.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer2", mat, 90.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer3", mat, 10.0, 0.125));
+        layers.add(new DataLayer(UUID.randomUUID().toString(), "Layer4", mat, 0.0, 0.125));
 
         Laminat lam = new Laminat(UUID.randomUUID().toString(), "Laminat1", false);
 

--- a/Classical_Laminated_Plate_Theory_Optimzation/src/de/elamx/clt/optimization/hauffe/HauffeOptimizer.java
+++ b/Classical_Laminated_Plate_Theory_Optimzation/src/de/elamx/clt/optimization/hauffe/HauffeOptimizer.java
@@ -28,6 +28,7 @@ package de.elamx.clt.optimization.hauffe;
 import de.elamx.clt.optimization.OptimizationInput;
 import de.elamx.clt.optimization.Optimizer;
 import de.elamx.clt.optimization.sda.SequentialDecisionApproach;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.DefaultMaterial;
 import de.elamx.laminate.Laminat;
 import de.elamx.laminate.Layer;
@@ -64,7 +65,7 @@ public class HauffeOptimizer extends Optimizer {
         double[] angles = input.getAngles();
         ArrayList<MinimalReserveFactorCalculator> calculators = input.getCalculators();
 
-        Layer baseLayer = new Layer("", "", input.getMaterial(), 0.0, input.getThickness(), input.getCriterion());
+        DataLayer baseLayer = new DataLayer("", "", input.getMaterial(), 0.0, input.getThickness(), input.getCriterion());
 
         boolean isSymmetricLaminateNeeded = false;
 
@@ -88,7 +89,7 @@ public class HauffeOptimizer extends Optimizer {
         params.setMaxLayerNum(sdaLam.getLayers().size() + params.getDeltaMaxLayerNum());
 
         // Bestimmung der minimalen Lagenanzahl mittels Superlagen
-        Layer superLayer = getSuperlayer();
+        DataLayer superLayer = getSuperlayer();
 
         Laminat laminat = new Laminat("", "", false);
         laminat.setSymmetric(isSymmetricLaminateNeeded || input.isSymmetricLaminat());
@@ -233,7 +234,7 @@ public class HauffeOptimizer extends Optimizer {
         return new Individuum(numLayer, angles);
     }
 
-    private void evalObjectiv(OptimizationInput input, Individuum indiv, Layer baseLayer, boolean isSymmetryNeeded) {
+    private void evalObjectiv(OptimizationInput input, Individuum indiv, DataLayer baseLayer, boolean isSymmetryNeeded) {
 
         Laminat laminat = IndividuumToLaminat(indiv, baseLayer, isSymmetryNeeded);
 
@@ -248,12 +249,12 @@ public class HauffeOptimizer extends Optimizer {
         indiv.setMinReserveFactor(minResFac);
     }
 
-    private Laminat IndividuumToLaminat(Individuum indiv, Layer baseLayer, boolean isSymmetryNeeded) {
+    private Laminat IndividuumToLaminat(Individuum indiv, DataLayer baseLayer, boolean isSymmetryNeeded) {
         Laminat laminat = new Laminat("", "", false);
         laminat.setSymmetric(isSymmetryNeeded || input.isSymmetricLaminat());
 
         double[] angles = indiv.getAngles();
-        Layer[] layers = new Layer[indiv.getNumLayers()];
+        DataLayer[] layers = new DataLayer[indiv.getNumLayers()];
 
         for (int ii = 0; ii < indiv.getNumLayers(); ii++) {
             layers[ii] = baseLayer.getCopyWithoutListeners(angles[ii]);
@@ -264,7 +265,7 @@ public class HauffeOptimizer extends Optimizer {
         return laminat;
     }
 
-    private Individuum permuteIndividuum(Individuum indiv, Layer baseLayer, boolean isSymmetryNeeded) {
+    private Individuum permuteIndividuum(Individuum indiv, DataLayer baseLayer, boolean isSymmetryNeeded) {
         double[] angles = input.getAngles();
         Individuum bestIndiv = indiv;
         for (int layNum = 0; layNum < indiv.getNumLayers(); layNum++) {
@@ -287,7 +288,7 @@ public class HauffeOptimizer extends Optimizer {
         return false;
     }
 
-    private Layer getSuperlayer() {
+    private DataLayer getSuperlayer() {
         double EPar = input.getMaterial().getEpar();
         double nue = 0.0;
         double G = EPar / (2.0 * (1.0 + nue));
@@ -314,6 +315,6 @@ public class HauffeOptimizer extends Optimizer {
             }
         }
 
-        return new Layer("", "Superlayer", superMaterial, 0.0, input.getThickness(), criterion);
+        return new DataLayer("", "Superlayer", superMaterial, 0.0, input.getThickness(), criterion);
     }
 }

--- a/Classical_Laminated_Plate_Theory_Optimzation/src/de/elamx/clt/optimization/sda/SequentialDecisionApproach.java
+++ b/Classical_Laminated_Plate_Theory_Optimzation/src/de/elamx/clt/optimization/sda/SequentialDecisionApproach.java
@@ -27,8 +27,8 @@ package de.elamx.clt.optimization.sda;
 
 import de.elamx.clt.optimization.OptimizationInput;
 import de.elamx.clt.optimization.Optimizer;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.Laminat;
-import de.elamx.laminate.Layer;
 import de.elamx.laminate.optimization.MinimalReserveFactorCalculator;
 import java.util.ArrayList;
 import java.util.UUID;
@@ -58,7 +58,7 @@ public class SequentialDecisionApproach extends Optimizer{
         double[] angles = input.getAngles();
         ArrayList<MinimalReserveFactorCalculator> calculators = input.getCalculators();
 
-        Layer baseLayer = new Layer("", NbBundle.getMessage(Optimizer.class, "Optimized_Layer") + " " + atomicLayerCounter.incrementAndGet(), input.getMaterial(), 0.0, input.getThickness(), input.getCriterion());
+        DataLayer baseLayer = new DataLayer("", NbBundle.getMessage(Optimizer.class, "Optimized_Layer") + " " + atomicLayerCounter.incrementAndGet(), input.getMaterial(), 0.0, input.getThickness(), input.getCriterion());
 
         Laminat laminat = new Laminat(UUID.randomUUID().toString(), NbBundle.getMessage(Optimizer.class, "Optimized_Laminate") + " " + atomicLaminateCounter.incrementAndGet(), false);
 
@@ -84,7 +84,7 @@ public class SequentialDecisionApproach extends Optimizer{
         int numberOfConstraintEvals = 0;
 
         while (minReserveFactor < 1.0) {
-            Layer actLayer = baseLayer.getCopyWithoutListeners(baseLayer.getAngle());
+            DataLayer actLayer = baseLayer.getCopyWithoutListeners(baseLayer.getAngle());
 
             laminat.addLayer(laminat.getNumberofLayers()/2,actLayer);
 

--- a/Classical_Laminated_Plate_Theory_UI/src/de/elamx/clt/calculation/calc/ResultTableModel.java
+++ b/Classical_Laminated_Plate_Theory_UI/src/de/elamx/clt/calculation/calc/ResultTableModel.java
@@ -159,7 +159,7 @@ public class ResultTableModel extends DefaultTableModel {
         if (off == 0) {
             switch (col) {
                 case 0:
-                    return Integer.toString(layInd + 1);
+                    return layerResults[layInd].getLayer().getNumber();
                 case 1:
                     return layerResults[layInd].getLayer().getName();
                 case 2:

--- a/Core/src/de/elamx/core/LaminatStringGenerator.java
+++ b/Core/src/de/elamx/core/LaminatStringGenerator.java
@@ -25,8 +25,8 @@
  */
 package de.elamx.core;
 
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.Laminat;
-import de.elamx.laminate.Layer;
 import java.util.ArrayList;
 
 /**
@@ -37,7 +37,7 @@ import java.util.ArrayList;
 public class LaminatStringGenerator {
 
     public static String getLaminatAsHTMLString(Laminat laminate) {
-        ArrayList<Layer> layers = laminate.getOriginalLayers();
+        ArrayList<DataLayer> layers = laminate.getOriginalLayers();
 
         String lamString = " ";
 

--- a/File_Support/src/de/elamx/filesupport/LaminateLoadSaveImpl.java
+++ b/File_Support/src/de/elamx/filesupport/LaminateLoadSaveImpl.java
@@ -25,6 +25,7 @@
  */
 package de.elamx.filesupport;
 
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.Laminat;
 import de.elamx.laminate.Layer;
 import de.elamx.laminate.LayerMaterial;
@@ -110,7 +111,7 @@ public class LaminateLoadSaveImpl implements LoadSaveHook{
                                     if (criterion == null) {
                                         criterion = criterionMap.get(Puck.class.getName());
                                     }
-                                    Layer layer = new Layer(uuid, name, material, angle, thickness, criterion);
+                                    DataLayer layer = new DataLayer(uuid, name, material, angle, thickness, criterion);
                                     laminate.addLayer(layer);
                                 }
                             }

--- a/LaminatEditor/src/de/elamx/laminateditor/CloneLayersAction.java
+++ b/LaminatEditor/src/de/elamx/laminateditor/CloneLayersAction.java
@@ -25,6 +25,7 @@
  */
 package de.elamx.laminateditor;
 
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.Layer;
 import de.elamx.laminateditor.LayerNodeFactory.LayerNode;
 import java.awt.Dialog;
@@ -73,10 +74,10 @@ public final class CloneLayersAction implements ActionListener {
                         if (ev.getSource() == DialogDescriptor.OK_OPTION) {
                             try {
                                 int n = numberPanel.getNumber();
-                                ArrayList<Layer> newLayers = new ArrayList<>(context.size() * n);
+                                ArrayList<DataLayer> newLayers = new ArrayList<>(context.size() * n);
                                 for (int ii = 0; ii < n; ii++) {
                                     for (LayerNode layerNode : context) {
-                                        newLayers.add(layerNode.getLookup().lookup(Layer.class).getCopy());
+                                        newLayers.add(layerNode.getLookup().lookup(DataLayer.class).getCopy());
                                     }
                                 }
                                 context.get(0).getLaminate().addLayers(newLayers);

--- a/LaminatEditor/src/de/elamx/laminateditor/CriterionProperty.java
+++ b/LaminatEditor/src/de/elamx/laminateditor/CriterionProperty.java
@@ -25,7 +25,7 @@
  */
 package de.elamx.laminateditor;
 
-import de.elamx.laminate.Layer;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.failure.Criterion;
 import java.awt.Component;
 import java.awt.event.ItemEvent;
@@ -54,10 +54,10 @@ import org.openide.util.lookup.Lookups;
  */
 public class CriterionProperty extends PropertySupport.ReadWrite<Criterion> {
 
-    Layer layer;
+    DataLayer layer;
 
-    public CriterionProperty(Layer layer) {
-        super(Layer.PROP_CRITERION, Criterion.class, NbBundle.getMessage(LayerNodeFactory.class, "LayerNode.Criterion"), NbBundle.getMessage(LayerNodeFactory.class, "LayerNode.Criterion.description"));
+    public CriterionProperty(DataLayer layer) {
+        super(DataLayer.PROP_CRITERION, Criterion.class, NbBundle.getMessage(LayerNodeFactory.class, "LayerNode.Criterion"), NbBundle.getMessage(LayerNodeFactory.class, "LayerNode.Criterion.description"));
         this.layer = layer;
     }
 
@@ -78,9 +78,9 @@ public class CriterionProperty extends PropertySupport.ReadWrite<Criterion> {
 
     private class CriterionPropertyEditorSupport extends PropertyEditorSupport implements ExPropertyEditor, InplaceEditor.Factory {
 
-        private final Layer layer;
+        private final DataLayer layer;
 
-        private CriterionPropertyEditorSupport(Layer layer) {
+        private CriterionPropertyEditorSupport(DataLayer layer) {
             this.layer = layer;
         }
 
@@ -116,11 +116,11 @@ public class CriterionProperty extends PropertySupport.ReadWrite<Criterion> {
     private class Inplace extends JComboBox<Criterion> implements InplaceEditor {
 
         private PropertyEditor editor = null;
-        private final Layer layer;
+        private final DataLayer layer;
         private final ItemListener myItemList = new MyItemListener();
         private boolean connecting = false;
 
-        private Inplace(final Layer layer) {
+        private Inplace(final DataLayer layer) {
             this.layer = layer;
         }
 

--- a/LaminatEditor/src/de/elamx/laminateditor/LaminatEditorTopComponent.java
+++ b/LaminatEditor/src/de/elamx/laminateditor/LaminatEditorTopComponent.java
@@ -27,8 +27,8 @@ package de.elamx.laminateditor;
 
 import de.elamx.core.GlobalProperties;
 import de.elamx.core.LaminateStringParser;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.Laminat;
-import de.elamx.laminate.Layer;
 import de.elamx.laminate.LayerMaterial;
 import de.elamx.laminate.eLamXLookup;
 import de.elamx.laminate.failure.Criterion;
@@ -121,10 +121,10 @@ public final class LaminatEditorTopComponent extends TopComponent implements Exp
     }
 
     private void initView() {
-        outlineView1.setPropertyColumns(Layer.PROP_ANGLE, NbBundle.getMessage(LayerNode.class, "LayerNode.Angle"),
-                Layer.PROP_THICKNESS, NbBundle.getMessage(LayerNode.class, "LayerNode.Thickness"),
-                Layer.PROP_MATERIAL, NbBundle.getMessage(LayerNode.class, "LayerNode.Material"),
-                Layer.PROP_CRITERION, NbBundle.getMessage(LayerNode.class, "LayerNode.Criterion"),
+        outlineView1.setPropertyColumns(DataLayer.PROP_ANGLE, NbBundle.getMessage(LayerNode.class, "LayerNode.Angle"),
+                DataLayer.PROP_THICKNESS, NbBundle.getMessage(LayerNode.class, "LayerNode.Thickness"),
+                DataLayer.PROP_MATERIAL, NbBundle.getMessage(LayerNode.class, "LayerNode.Material"),
+                DataLayer.PROP_CRITERION, NbBundle.getMessage(LayerNode.class, "LayerNode.Criterion"),
                 "Number", NbBundle.getMessage(LayerNode.class, "LayerNode.Number"),
                 "ZM", NbBundle.getMessage(LayerNode.class, "LayerNode.ZM"));
         ((DefaultOutlineModel) outlineView1.getOutline().getModel()).setNodesColumnLabel(NbBundle.getMessage(LayerNode.class, "LayerNode.Name"));
@@ -551,7 +551,7 @@ public final class LaminatEditorTopComponent extends TopComponent implements Exp
 
     private void rotateButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_rotateButtonActionPerformed
         double rotAngle = ((Number) rotationAngleField.getValue()).doubleValue();
-        for (Layer l : laminat.getOriginalLayers()) {
+        for (DataLayer l : laminat.getOriginalLayers()) {
             l.setAngle(rotAngle + l.getAngle());
         }
     }//GEN-LAST:event_rotateButtonActionPerformed
@@ -590,9 +590,9 @@ public final class LaminatEditorTopComponent extends TopComponent implements Exp
                 return;
             }
 
-            List<Layer> layers = new ArrayList<>(angles.length);
+            List<DataLayer> layers = new ArrayList<>(angles.length);
             for (double a : angles) {
-                layers.add(new Layer(UUID.randomUUID().toString(), name, material, a, thickness, criterion));
+                layers.add(new DataLayer(UUID.randomUUID().toString(), name, material, a, thickness, criterion));
             }
             laminat.addLayers(layers);
         } else {

--- a/LaminatEditor/src/de/elamx/laminateditor/LaminateNode.java
+++ b/LaminatEditor/src/de/elamx/laminateditor/LaminateNode.java
@@ -25,7 +25,7 @@
  */
 package de.elamx.laminateditor;
 
-import de.elamx.laminate.Layer;
+import de.elamx.laminate.DataLayer;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
@@ -77,7 +77,7 @@ public class LaminateNode extends AbstractNode {
                 @Override
                 public Transferable paste() throws IOException {
                     try {
-                        layers.addLayer((Layer) t.getTransferData(LayerFlavor.LAYER_FLAVOR));
+                        layers.addLayer((DataLayer) t.getTransferData(LayerFlavor.LAYER_FLAVOR));
                         final Node node = NodeTransfer.node(t, NodeTransfer.DND_MOVE + NodeTransfer.CLIPBOARD_CUT);
                         if (node != null) {
                             node.destroy();

--- a/LaminatEditor/src/de/elamx/laminateditor/LayerNodeFactory.java
+++ b/LaminatEditor/src/de/elamx/laminateditor/LayerNodeFactory.java
@@ -27,6 +27,7 @@ package de.elamx.laminateditor;
 
 import de.elamx.core.propertyeditor.AnglePropertyEditorSupport;
 import de.elamx.core.propertyeditor.ThicknessPropertyEditorSupport;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.Laminat;
 import de.elamx.laminate.Layer;
 import de.elamx.laminateditor.LayerNodeFactory.LayerProxy;
@@ -67,14 +68,14 @@ public class LayerNodeFactory extends ChildFactory<LayerProxy> implements Proper
         this.laminat.addPropertyChangeListener(this);
     }
 
-    public void addLayer(Layer l) {
+    public void addLayer(DataLayer l) {
         changing = true;
         laminat.addLayer(l);
         refresh(true);
         changing = false;
     }
 
-    private void removeLayer(Layer l) {
+    private void removeLayer(DataLayer l) {
         changing = true;
         laminat.removeLayer(l);
         refresh(true);
@@ -83,7 +84,7 @@ public class LayerNodeFactory extends ChildFactory<LayerProxy> implements Proper
 
     @Override
     protected boolean createKeys(List<LayerProxy> toPopulate) {
-        ArrayList<Layer> layTemp = laminat.getOriginalLayers();
+        ArrayList<DataLayer> layTemp = laminat.getOriginalLayers();
 
         int number = 1;
       
@@ -134,8 +135,8 @@ public class LayerNodeFactory extends ChildFactory<LayerProxy> implements Proper
     }
 
     public void reorder(int[] perm) {
-        ArrayList<Layer> layers = laminat.getOriginalLayers();
-        Layer[] reordered = new Layer[layers.size()];
+        ArrayList<DataLayer> layers = laminat.getOriginalLayers();
+        DataLayer[] reordered = new DataLayer[layers.size()];
 
         // Wenn Ablage im Bereich der Symmetrielagen tue nichts
         for (int i = 0; i < layers.size(); i++) {
@@ -148,7 +149,7 @@ public class LayerNodeFactory extends ChildFactory<LayerProxy> implements Proper
         for (int i = 0; i < layers.size(); i++) {
             int j = perm[i];
 
-            Layer l = layers.get(i);
+            DataLayer l = layers.get(i);
             reordered[j] = l;
         }
         changing = true;
@@ -253,7 +254,7 @@ public class LayerNodeFactory extends ChildFactory<LayerProxy> implements Proper
 
         @Override
         public void destroy() throws IOException {
-            removeLayer(getLookup().lookup(Layer.class));
+            removeLayer(getLookup().lookup(DataLayer.class));
         }
 
         @Override
@@ -346,13 +347,13 @@ public class LayerNodeFactory extends ChildFactory<LayerProxy> implements Proper
                 generalProp.put(angleProp);
                 generalProp.put(thickProp);
                 generalProp.put(zm);
-                generalProp.put(new MaterialProperty(layer) {
+                generalProp.put(new MaterialProperty((DataLayer) layer) {
                     @Override
                     public boolean canWrite() {
                         return symmetryLayer;
                     }
                 });
-                generalProp.put(new CriterionProperty(layer) {
+                generalProp.put(new CriterionProperty((DataLayer) layer) {
                     @Override
                     public boolean canWrite() {
                         return symmetryLayer;

--- a/LaminatEditor/src/de/elamx/laminateditor/MaterialProperty.java
+++ b/LaminatEditor/src/de/elamx/laminateditor/MaterialProperty.java
@@ -25,7 +25,7 @@
  */
 package de.elamx.laminateditor;
 
-import de.elamx.laminate.Layer;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.LayerMaterial;
 import de.elamx.laminate.eLamXLookup;
 import java.awt.Component;
@@ -53,10 +53,10 @@ import org.openide.util.NbBundle;
  */
 public class MaterialProperty extends PropertySupport.ReadWrite<LayerMaterial> {
 
-    Layer layer;
+    DataLayer layer;
 
-    public MaterialProperty(Layer layer) {
-        super(Layer.PROP_MATERIAL, LayerMaterial.class, NbBundle.getMessage(LayerNodeFactory.class, "LayerNode.Material"), NbBundle.getMessage(LayerNodeFactory.class, "LayerNode.Material.description"));
+    public MaterialProperty(DataLayer layer) {
+        super(DataLayer.PROP_MATERIAL, LayerMaterial.class, NbBundle.getMessage(LayerNodeFactory.class, "LayerNode.Material"), NbBundle.getMessage(LayerNodeFactory.class, "LayerNode.Material.description"));
         this.layer = layer;
     }
 
@@ -77,9 +77,9 @@ public class MaterialProperty extends PropertySupport.ReadWrite<LayerMaterial> {
 
     private class MaterialPropertyEditorSupport extends PropertyEditorSupport implements ExPropertyEditor, InplaceEditor.Factory {
 
-        private final Layer layer;
+        private final DataLayer layer;
 
-        private MaterialPropertyEditorSupport(Layer layer) {
+        private MaterialPropertyEditorSupport(DataLayer layer) {
             this.layer = layer;
         }
 
@@ -115,11 +115,11 @@ public class MaterialProperty extends PropertySupport.ReadWrite<LayerMaterial> {
     private class Inplace extends JComboBox<LayerMaterial> implements InplaceEditor {
 
         private PropertyEditor editor = null;
-        private final Layer layer;
+        private final DataLayer layer;
         private final ItemListener myItemList = new MyItemListener();
         private boolean connecting = false;
 
-        private Inplace(final Layer layer) {
+        private Inplace(final DataLayer layer) {
             this.layer = layer;
         }
 

--- a/LaminatEditor/src/de/elamx/laminateditor/RemoveLayerAction.java
+++ b/LaminatEditor/src/de/elamx/laminateditor/RemoveLayerAction.java
@@ -25,7 +25,7 @@
  */
 package de.elamx.laminateditor;
 
-import de.elamx.laminate.Layer;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminateditor.LayerNodeFactory.LayerNode;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -56,10 +56,10 @@ public final class RemoveLayerAction implements ActionListener {
             return;
         }
         
-        ArrayList<Layer> layers = new ArrayList<>(context.size());
+        ArrayList<DataLayer> layers = new ArrayList<>(context.size());
         
         for (LayerNode layerNode : context) {
-            layers.add(layerNode.getLookup().lookup(Layer.class));
+            layers.add(layerNode.getLookup().lookup(DataLayer.class));
         }
         
         context.get(0).getLaminate().removeLayers(layers);

--- a/Laminate/src/de/elamx/laminate/DataLayer.java
+++ b/Laminate/src/de/elamx/laminate/DataLayer.java
@@ -241,12 +241,16 @@ public class DataLayer extends Layer {
      */
     @Override
     public DataLayer getCopy() {
-        return new DataLayer(UUID.randomUUID().toString(), getName(), material, angle, thickness, criterion);
+        DataLayer dataLayerCopy = new DataLayer(UUID.randomUUID().toString(), getName(), material, angle, thickness, criterion);
+        dataLayerCopy.setNumber(this.getNumber());
+        return dataLayerCopy;
     }
     
     @Override
     public DataLayer getCopyWithoutListeners(double angle) {
-        return new DataLayer("", getName(), material, angle, thickness, criterion, false);
+        DataLayer dataLayerCopy = new DataLayer("", getName(), material, angle, thickness, criterion, false);
+        dataLayerCopy.setNumber(this.getNumber());
+        return dataLayerCopy;
     }
 
     @Override

--- a/Laminate/src/de/elamx/laminate/DataLayer.java
+++ b/Laminate/src/de/elamx/laminate/DataLayer.java
@@ -1,0 +1,256 @@
+/*
+ *  This program developed in Java is based on the netbeans platform and is used
+ *  to design and to analyse composite structures by means of analytical and 
+ *  numerical methods.
+ * 
+ *  Further information can be found here:
+ *  http://www.elamx.de
+ *    
+ *  Copyright (C) 2021 Technische Universität Dresden - Andreas Hauffe
+ * 
+ *  This file is part of eLamX².
+ *
+ *  eLamX² is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  eLamX² is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with eLamX².  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.elamx.laminate;
+
+import de.elamx.laminate.failure.Criterion;
+import de.elamx.laminate.failure.Puck;
+import java.beans.PropertyChangeEvent;
+import java.util.Collection;
+import java.util.UUID;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+/**
+ * Definiert eine Lage im Laminat.
+ *
+ * @author Andreas Hauffe
+ */
+public class DataLayer extends Layer {
+
+    // Winkel
+    private double angle = 0.0;
+    // Dicke der Schicht
+    private double thickness = 0.0;
+    // Matrial der Lage
+    private LayerMaterial material = null;
+    // z-Koordinate der Mittelebene dieser Schicht
+    //private double   zm        = 0.0;
+    //public static final String PROP_ZM = "zm";
+    // Versagenskriterium
+    private Criterion criterion = null;
+    // Flag, ob die Lage oberhalb und unterhalb noch weitere Lagen berührt
+    // für Versagenskriterien wichtig!
+    private boolean embedded;
+
+    public DataLayer(String uid, String name, LayerMaterial material, double angle, double thickness) {
+        this(uid, name, material, angle, thickness, null);
+    }
+
+    public DataLayer(String uid, String name, LayerMaterial material, double angle, double thickness, Criterion criterion) {
+        this(uid, name, material, angle, thickness, criterion, false);
+    }
+    
+    private DataLayer(String uid, String name, LayerMaterial material, double angle, double thickness, Criterion criterion, boolean withListeners) {
+        super(uid, name);
+        this.material = material;
+        if (withListeners){
+            material.addPropertyChangeListener(this);
+        }
+        this.angle = reduceAngle(angle);
+        this.thickness = thickness;
+        this.criterion = criterion;
+
+        if (this.criterion == null) {
+            Lookup lkp = Lookups.forPath("elamx/failurecriteria");
+            Collection<? extends Criterion> c = lkp.lookupAll(Criterion.class);
+            for (Criterion crit : c) {
+                if (crit instanceof Puck) {
+                    this.criterion = crit;
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Liefert den Winkel der Lage im Laminatsystem im Gradmaß.
+     * @return Winkel im Gradmaß
+     */
+    @Override
+    public double getAngle() {
+        return angle;
+    }
+    
+    /**
+     * Liefert den Winkel der Lage im Laminatsystem im Bogenmaß.
+     * @return Winkel im Bogenmaß
+     */
+    @Override
+    public double getRadAngle() {
+        return Math.toRadians(angle);
+    }
+
+    private static double reduceAngle(final double angle) {
+        double sign = Math.signum(angle);
+        double a = Math.abs(angle);
+
+        a %= 180.0;
+        if (a > 90.0) {
+            a -= 180.0;
+        }
+        return sign * a;
+    }
+
+    /**
+     * Setzen den Winkels der Lage im Laminatsystem im Gradmaß. Der Winkel wird
+     * dabei solange mit 180° modifiziert bis -90° &le; angle &le; 90°.
+     *
+     * @param angle Winkel im Gradmaß
+     */
+    public void setAngle(double angle) {
+        double oldAngle = this.angle;
+        this.angle = reduceAngle(angle);
+        firePropertyChange(PROP_ANGLE, oldAngle, this.angle);
+    }
+
+    /**
+     * Liefert das Materialobjekt der Lage zurück.
+     *
+     * @return Materialobjekt
+     */
+    @Override
+    public LayerMaterial getMaterial() {
+        return material;
+    }
+
+    /**
+     * Setzen des Materials der Lage.
+     *
+     * @param material Neues Material der Lage
+     */
+    public void setMaterial(LayerMaterial material) {
+        LayerMaterial oldMaterial = this.material;
+        oldMaterial.removePropertyChangeListener(this);
+        this.material = material;
+        this.material.addPropertyChangeListener(this);
+        firePropertyChange(PROP_MATERIAL, oldMaterial, this.material);
+    }
+
+    /**
+     * Liefert die Dicke dieser Lage.
+     *
+     * @return Dicke der Lage
+     */
+    @Override
+    public double getThickness() {
+        return thickness;
+    }
+
+    /**
+     * Setzen der Dicke der Lage.
+     *
+     * @param thickness Dicke der Lage
+     */
+    public void setThickness(double thickness) {
+        double oldThickness = this.thickness;
+        this.thickness = thickness;
+        firePropertyChange(PROP_THICKNESS, oldThickness, this.thickness);
+    }
+
+    /**
+     * Liefert die Z-Position der Lage im Laminat
+     *
+     * @return z-Position der Lage im Laminat
+     */
+    /*public double getZm() {
+     return zm;
+     }*/
+    /**
+     * Setzen der z-Position der Lage im Laminat.
+     *
+     * @param zm z-Position der Lage im Laminat
+     */
+    /*public void setZm(double zm) {
+     double oldZm = this.zm;
+     this.zm = zm;
+     firePropertyChange(PROP_ZM, oldZm, this.zm);
+     }*/
+
+    /**
+     * Liefert das Versagenskriterium zurück.
+     *
+     * @return Versagenskriterium
+     */
+    @Override
+    public Criterion getCriterion() {
+        return criterion;
+    }
+
+    /**
+     * Setzen des Versagenskriteriums der Lage im Laminat.
+     *
+     * @param criterion Versagenskriterium der Lages
+     */
+    public void setCriterion(Criterion criterion) {
+        Criterion oldCriterion = this.criterion;
+        this.criterion = criterion;
+        firePropertyChange(PROP_CRITERION, oldCriterion, this.criterion);
+    }
+    
+    /**
+     * Liefert zurück, ob die Lage von weiteren Lagen umgeben ist oder am
+     * Rand des Laminats liegt. Dies ist für einige Versagenskriterien wichtig.
+     *
+     * @return true, wenn die Lage von weiteren Lagen umgeben ist
+     */
+    @Override
+    public boolean isEmbedded() {
+        return embedded;
+    }
+
+    /**
+     * Setzt, ob die Lage von weiteren Lagen umgeben ist oder am
+     * Rand des Laminats liegt.
+     *
+     * @param embedded new value of embedded
+     */
+    protected void setEmbedded(boolean embedded) {
+        boolean oldEmbedded = this.embedded;
+        this.embedded = embedded;
+        firePropertyChange(PROP_EMBEDDED, oldEmbedded, embedded);
+    }
+
+    /**
+     * Liefert ein neues
+     * <CODE>Layer</CODE>-Objekt mit den selben Eigenschaften.
+     *
+     * @return Kopie dieser Lage
+     */
+    @Override
+    public DataLayer getCopy() {
+        return new DataLayer(UUID.randomUUID().toString(), getName(), material, angle, thickness, criterion);
+    }
+    
+    @Override
+    public DataLayer getCopyWithoutListeners(double angle) {
+        return new DataLayer("", getName(), material, angle, thickness, criterion, false);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        this.firePropertyChange(PROP_MATERIAL, null, material);
+    }
+}

--- a/Laminate/src/de/elamx/laminate/Laminat.java
+++ b/Laminate/src/de/elamx/laminate/Laminat.java
@@ -43,7 +43,7 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
     
     private static final int UPDATE_PRIORITY = 300;
     
-    private ArrayList<Layer> layers = new ArrayList<>(); // Array, das alle Lagen enthält (bei Symmetrie nur eine Hälfte)
+    private ArrayList<DataLayer> layers = new ArrayList<>(); // Array, das alle Lagen enthält (bei Symmetrie nur eine Hälfte)
     
     // Flag, ob das Laminate symmetrisch ist
     private boolean symmetric       = false;
@@ -168,14 +168,14 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
      * Hinzufügen einer Schicht zum Laminat. Die Schicht wird ans Ende angehängt.
      * @param layer Schicht, die angehängt werden soll
      */
-    public void addLayer(Layer layer){
+    public void addLayer(DataLayer layer){
         layers.add(layer);
         layer.addPropertyChangeListener(this);
         checkEmbedded();
         firePropertyChange(PROP_STACKING, null, this);
     }
     
-    public void addLayer(int index, Layer layer){
+    public void addLayer(int index, DataLayer layer){
         layers.add(index, layer);
         layer.addPropertyChangeListener(this);
         checkEmbedded();
@@ -188,7 +188,7 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
      * @param index Index, an den die Schicht eingefügt werden soll
      * @param layer Schicht
      */
-    public void setLayer(int index, Layer layer){
+    public void setLayer(int index, DataLayer layer){
         layers.get(index).removePropertyChangeListener(this);
         layers.set(index, layer);
         layers.get(index).addPropertyChangeListener(this);
@@ -220,7 +220,7 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
         firePropertyChange(PROP_STACKING, null, this);
     }
     
-    public void removeLayers(List<Layer> layer){
+    public void removeLayers(List<DataLayer> layer){
         for (Layer l : layer){
             if (layers.remove(l)){
                 l.removePropertyChangeListener(this);
@@ -235,8 +235,8 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
      * Schichtaufbaus angehängt.
      * @param layer 
      */
-    public void addLayers(List<Layer> layer){
-        for (Layer l : layer) {
+    public void addLayers(List<DataLayer> layer){
+        for (DataLayer l : layer) {
             l.addPropertyChangeListener(this);
         }
         layers.addAll(layer);
@@ -311,14 +311,19 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
                 start--;
             }
             for (int ii = start; ii >= 0; ii--){
-                layTemp.add(layers.get(ii));
+                DataLayer dataLayer = layers.get(ii);
+                layTemp.add(new SymmetricLayer(UUID.randomUUID().toString(), dataLayer.getName(), dataLayer));
             }
+        }
+
+        for (int ind=0; ind<layTemp.size();  ind++) {
+            layTemp.get(ind).setNumber(ind + 1);
         }
 
         if (invertZ){
             Collections.reverse(layTemp);
         }
-        
+
         return layTemp;
     }
     
@@ -332,10 +337,14 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
         ArrayList<Layer> layTemp = new ArrayList<>();
         layTemp.addAll(layers);
 
-        if (invertZ && (!symmetric)){
+        for (int ind=0; ind<layTemp.size();  ind++) {
+            layTemp.get(ind).setNumber(ind + 1);
+        }
+
+        if (invertZ){
             Collections.reverse(layTemp);
         }
-        
+
         return layTemp;
     }
     
@@ -346,7 +355,7 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
      * auf den Laminataufbau des Laminates.
      * @return Originale ArrayList mit allen Lagen.
      */
-    public ArrayList<Layer> getOriginalLayers(){
+    public ArrayList<DataLayer> getOriginalLayers(){
         return layers;
     }
     
@@ -389,7 +398,7 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
     
     public Laminat getCopy(boolean addToLookup){
         Laminat lam = new Laminat(UUID.randomUUID().toString(), this.getName(), addToLookup);
-        for(Layer l : layers){
+        for(DataLayer l : layers){
             lam.addLayer(l.getCopy());
         }
         lam.setSymmetric(symmetric);
@@ -401,7 +410,7 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
     
     public Laminat getCopyWithoutListener(boolean addToLookup){
         Laminat lam = new Laminat(UUID.randomUUID().toString(), this.getName(), addToLookup);
-        for(Layer l : layers){
+        for(DataLayer l : layers){
             lam.addLayer(l.getCopyWithoutListeners(l.getAngle()));
         }
         lam.setSymmetric(symmetric);
@@ -416,7 +425,7 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
     private void checkEmbedded() {
         if (symmetric) {
             int i = 0;
-            for (Layer l : layers) {
+            for (DataLayer l : layers) {
                 if (i == 0) {
                     l.setEmbedded(false);
                 } else {
@@ -426,7 +435,7 @@ public class Laminat extends ELamXObject implements PropertyChangeListener, Look
             }
         } else {
             int i = 0;
-            for (Layer l : layers) {
+            for (DataLayer l : layers) {
                 if (i == 0 | i == (layers.size() - 1)) {
                     l.setEmbedded(false);
                 } else{

--- a/Laminate/src/de/elamx/laminate/SymmetricLayer.java
+++ b/Laminate/src/de/elamx/laminate/SymmetricLayer.java
@@ -1,0 +1,114 @@
+/*
+ *  This program developed in Java is based on the netbeans platform and is used
+ *  to design and to analyse composite structures by means of analytical and 
+ *  numerical methods.
+ * 
+ *  Further information can be found here:
+ *  http://www.elamx.de
+ *    
+ *  Copyright (C) 2021 Technische Universität Dresden - Andreas Hauffe
+ * 
+ *  This file is part of eLamX².
+ *
+ *  eLamX² is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  eLamX² is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with eLamX².  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.elamx.laminate;
+
+import de.elamx.laminate.failure.Criterion;
+import java.beans.PropertyChangeEvent;
+import java.util.UUID;
+
+/**
+ * Definiert eine Lage im Laminat.
+ *
+ * @author Andreas Hauffe
+ */
+public class SymmetricLayer extends Layer {
+
+    private DataLayer dataLayer;
+
+    public SymmetricLayer(String uid, String name, DataLayer dataLayer) {
+        super(uid, name);
+        this.dataLayer = dataLayer;
+    }
+
+    /**
+     * Liefert den Winkel der Lage im Laminatsystem im Gradmaß.
+     * @return Winkel im Gradmaß
+     */
+    @Override
+    public double getAngle() {
+        return this.dataLayer.getAngle();
+    }
+
+    /**
+     * Liefert das Materialobjekt der Lage zurück.
+     *
+     * @return Materialobjekt
+     */
+    @Override
+    public LayerMaterial getMaterial() {
+        return this.dataLayer.getMaterial();
+    }
+
+    /**
+     * Liefert die Dicke dieser Lage.
+     *
+     * @return Dicke der Lage
+     */
+    @Override
+    public double getThickness() {
+        return this.dataLayer.getThickness();
+    }
+
+    /**
+     * Liefert das Versagenskriterium zurück.
+     *
+     * @return Versagenskriterium
+     */
+    @Override
+    public Criterion getCriterion() {
+        return this.dataLayer.getCriterion();
+    }
+    
+    /**
+     * Liefert zurück, ob die Lage von weiteren Lagen umgeben ist oder am
+     * Rand des Laminats liegt. Dies ist für einige Versagenskriterien wichtig.
+     *
+     * @return true, wenn die Lage von weiteren Lagen umgeben ist
+     */
+    @Override
+    public boolean isEmbedded() {
+        return this.dataLayer.isEmbedded();
+    }
+
+    /**
+     * Liefert ein neues
+     * <CODE>Layer</CODE>-Objekt mit den selben Eigenschaften.
+     *
+     * @return Kopie dieser Lage
+     */
+    @Override
+    public SymmetricLayer getCopy() {
+        return new SymmetricLayer(UUID.randomUUID().toString(), getName(), dataLayer);
+    }
+
+    @Override
+    public Layer getCopyWithoutListeners(double angle) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) { }
+}

--- a/Laminate/src/de/elamx/laminate/SymmetricLayer.java
+++ b/Laminate/src/de/elamx/laminate/SymmetricLayer.java
@@ -101,7 +101,9 @@ public class SymmetricLayer extends Layer {
      */
     @Override
     public SymmetricLayer getCopy() {
-        return new SymmetricLayer(UUID.randomUUID().toString(), getName(), dataLayer);
+        SymmetricLayer symmetricLayerCopy = new SymmetricLayer(UUID.randomUUID().toString(), getName(), dataLayer);
+        symmetricLayerCopy.setNumber(this.getNumber());
+        return symmetricLayerCopy;
     }
 
     @Override

--- a/LaminateFailureBody/src/de/elamx/laminatfailurebody/PlyFailureCriterion.java
+++ b/LaminateFailureBody/src/de/elamx/laminatfailurebody/PlyFailureCriterion.java
@@ -33,6 +33,7 @@ import com.ardor3d.scenegraph.MeshData;
 import com.ardor3d.util.geom.BufferUtils;
 import de.elamx.clt.CLT_Laminate;
 import de.elamx.clt.CLT_Layer;
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.DefaultMaterial;
 import de.elamx.laminate.Laminat;
 import de.elamx.laminate.Layer;
@@ -202,7 +203,7 @@ public class PlyFailureCriterion{
         */
         for (int ii = 0; ii < origLayers.length; ii++){
             Layer oldL = origLayers[ii].getLayer();
-            Layer newL = new Layer("1", "noname", getAsDefaultMaterial(oldL.getMaterial()), oldL.getAngle(), oldL.getThickness(), oldL.getCriterion());
+            Layer newL = new DataLayer("1", "noname", getAsDefaultMaterial(oldL.getMaterial()), oldL.getAngle(), oldL.getThickness(), oldL.getCriterion());
             layers[ii] = new CLT_Layer(newL);
             layers[ii].setZm(origLayers[ii].getZm());
             ZFB[ii]    = false;
@@ -301,7 +302,7 @@ public class PlyFailureCriterion{
                     for (mm = 0; mm < numLayers; mm++){
                         ZFB[mm] = false;
                         numZFBLayers = 0;
-                        layers[mm].getLayer().setMaterial(getAsDefaultMaterial(origLayers[mm].getLayer().getMaterial()));
+                        ((DataLayer) layers[mm].getLayer()).setMaterial(getAsDefaultMaterial(origLayers[mm].getLayer().getMaterial()));
                     }
                     ABDmatInv = getABDMatInv(layers, ZFB);
                 }

--- a/eLamX1Import/src/de/elamx/elamx1import/ImporteLamX1Action.java
+++ b/eLamX1Import/src/de/elamx/elamx1import/ImporteLamX1Action.java
@@ -25,9 +25,9 @@
  */
 package de.elamx.elamx1import;
 
+import de.elamx.laminate.DataLayer;
 import de.elamx.laminate.DefaultMaterial;
 import de.elamx.laminate.Laminat;
-import de.elamx.laminate.Layer;
 import de.elamx.laminate.eLamXLookup;
 import de.elamx.laminate.failure.Criterion;
 import de.elamx.laminate.failure.Puck;
@@ -107,7 +107,7 @@ public final class ImporteLamX1Action implements ActionListener {
                 int layerInd = 0;
                 while (true){
                     
-                    Layer layer = readLayer(prop, layerInd);
+                    DataLayer layer = readLayer(prop, layerInd);
                     if (layer == null) break;
 
                     lam.addLayer(layer);
@@ -146,7 +146,7 @@ public final class ImporteLamX1Action implements ActionListener {
         }
     }
     
-    private Layer readLayer(Properties prop, int layerInd){
+    private DataLayer readLayer(Properties prop, int layerInd){
         
         String keyPrefix = "Layer" + layerInd + ".";
         
@@ -229,7 +229,7 @@ public final class ImporteLamX1Action implements ActionListener {
             criterion = criterionMap.get(Puck.class.getName());
         }
 
-        Layer layer = new Layer(UUID.randomUUID().toString(), name, material, angle, thick, criterion);
+        DataLayer layer = new DataLayer(UUID.randomUUID().toString(), name, material, angle, thick, criterion);
         
         
         return layer;


### PR DESCRIPTION
+ `Layer` zu abstrakter Klasse geändert, die die Lagennummer beinhaltet;
+ `DataLayer` entspricht der bisherigen `Layer`-Klasse und implementiert Getter und Setter für Lagendaten;
+ `SymmetricLayer` dient für nicht editierbare, gespiegelte Symmetrielagen; die Daten werden aus der zugehörigen `DataLayer` Klasse entnommen;
+ In `Laminat` erfolgt in den Routinen `getLayers` und `getAllLayers` eine Zusammenstellung der `Layer`; in diesem Zuge wird auch die Lagennummer festgelegt, sodass bis dahin eine freie Editierbarkeit geben ist;
+ Die Behandlung der Symmetrieoption erfolgt nun in `getAllLayers` von `Laminat` anstelle von der bisherigen Behandlung in `initCLTLayers` von `CLT_Laminate`;
+ In der Ergebnisausgabe `ResultTableModel` wird die angezeigte Lagennummer dem `Layer` entnommen;