### PR TITLE
Warnungen bezüglich Materialdaten in GUI-Modul verschoben

### DIFF
--- a/File_View/src/de/elamx/fileview/nodes/Bundle.properties
+++ b/File_View/src/de/elamx/fileview/nodes/Bundle.properties
@@ -65,3 +65,6 @@ LaminateNode.Offset=Offset
 DefaultMaterial.ADDITIONALPROPERTIES=Additional Properties
 MaterialNode.name=Materials
 LaminatesNode.name=Laminates
+Warning.negativeelasticmodulus=<html>A negative elastic modulus has been defined.<br>Please check your input.</html>
+Warning.negativeshearmodulus=<html>A negative shear modulus has been defined.<br>Please check your input.</html>
+Warning.negativepoissonratio=<html>A negative Poisson's ratio has been defined.<br>Please check your input.</html>

--- a/File_View/src/de/elamx/fileview/nodes/Bundle_de.properties
+++ b/File_View/src/de/elamx/fileview/nodes/Bundle_de.properties
@@ -46,3 +46,6 @@ DefaultMaterial.SHEARMODULUS13.description=<html>transversaler Schubmodul der Sc
 DefaultMaterial.SHEARMODULUS13=transversaler Schubmodul
 DefaultMaterial.SHEARMODULUS23.description=<html>transversaler Schubmodul der Schicht [N/mm<sup>2</sup>]</html>
 DefaultMaterial.SHEARMODULUS23=transversaler Schubmodul
+Warning.negativeelasticmodulus=<html>Es wurde ein negativer Elastizit\u00e4tsmodul definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>
+Warning.negativeshearmodulus=<html>Es wurde ein negativer Schubmodul definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>
+Warning.negativepoissonratio=<html>Es wurde eine negative Querkontraktionszahl definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>

--- a/File_View/src/de/elamx/fileview/nodes/DefaultMaterialNode.java
+++ b/File_View/src/de/elamx/fileview/nodes/DefaultMaterialNode.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 import javax.swing.Action;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.awt.Actions;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
@@ -296,6 +298,21 @@ public class DefaultMaterialNode extends AbstractNode implements PropertyChangeL
         if (evt.getPropertyName().equals(Material.PROP_NAME)) {
             this.fireDisplayNameChange((String) evt.getOldValue(), (String) evt.getNewValue());
             return;
+        }
+        if (evt.getPropertyName().equals(DefaultMaterial.PROP_EPAR) || evt.getPropertyName().equals(DefaultMaterial.PROP_ENOR))  {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterialNode.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
+            }
+        }
+        if (evt.getPropertyName().equals(DefaultMaterial.PROP_NUE12)) {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterialNode.class, "Warning.negativepoissonratio"), NotifyDescriptor.WARNING_MESSAGE));
+            }
+        }
+        if (evt.getPropertyName().equals(DefaultMaterial.PROP_G) || evt.getPropertyName().equals(DefaultMaterial.PROP_G13) || evt.getPropertyName().equals(DefaultMaterial.PROP_G23)) {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterialNode.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
+            }
         }
         this.firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
     }

--- a/Laminate/src/de/elamx/laminate/Bundle.properties
+++ b/Laminate/src/de/elamx/laminate/Bundle.properties
@@ -2,6 +2,3 @@ OpenIDE-Module-Name=Laminate
 LaminateSummaryTableModel.Table.caption.angle=Angle
 LaminateSummaryTableModel.Table.caption.sumti=<html>&Sigma t<sub>i</sub></html>
 LaminateSummaryTableModel.Table.caption.percti=<html>% t<sub>tot</sub></html>
-Warning.negativeelasticmodulus=<html>A negative elastic modulus has been defined.<br>Please check your input.</html>
-Warning.negativeshearmodulus=<html>A negative shear modulus has been defined.<br>Please check your input.</html>
-Warning.negativepoissonratio=<html>A negative Poisson's ratio has been defined.<br>Please check your input.</html>

--- a/Laminate/src/de/elamx/laminate/Bundle_de.properties
+++ b/Laminate/src/de/elamx/laminate/Bundle_de.properties
@@ -3,6 +3,3 @@
 # and open the template in the editor.
 LaminateSummaryTableModel.Table.caption.angle=Winkel
 LaminateSummaryTableModel.Table.caption.percti=<html>% t<sub>ges</sub></html>
-Warning.negativeelasticmodulus=<html>Es wurde ein negativer Elastizit\u00e4tsmodul definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>
-Warning.negativeshearmodulus=<html>Es wurde ein negativer Schubmodul definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>
-Warning.negativepoissonratio=<html>Es wurde eine negative Querkontraktionszahl definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>

--- a/Laminate/src/de/elamx/laminate/DefaultMaterial.java
+++ b/Laminate/src/de/elamx/laminate/DefaultMaterial.java
@@ -27,9 +27,6 @@ package de.elamx.laminate;
 
 import java.util.Objects;
 import java.util.UUID;
-import org.openide.DialogDisplayer;
-import org.openide.NotifyDescriptor;
-import org.openide.util.NbBundle;
 
 /**
  *
@@ -122,9 +119,6 @@ public class DefaultMaterial extends LayerMaterial{
         double oldEpar = this.Epar;
         this.Epar = Epar;
         firePropertyChange(PROP_EPAR, oldEpar, Epar);
-        if ((Epar != oldEpar) && (Epar < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterial.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert den E-Modul in Faserrichtung E<sub>||</sub> des Materials.
@@ -141,9 +135,6 @@ public class DefaultMaterial extends LayerMaterial{
         double oldEnor = this.Enor;
         this.Enor = Enor;
         firePropertyChange(PROP_ENOR, oldEnor, this.Enor);
-        if ((Enor != oldEnor) && (Enor < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterial.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert den E-Modul quer zur Faserrichtung E<sub>&perp;</sub> des Materials.
@@ -162,9 +153,6 @@ public class DefaultMaterial extends LayerMaterial{
         double oldNue12 = this.nue12;
         nue12 = nue;
         firePropertyChange(PROP_NUE12, oldNue12, nue12);
-        if ((nue != oldNue12) && (nue < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterial.class, "Warning.negativepoissonratio"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert die Querkontraktionszahl &nu;<sub>12</sub> des Materials. Dabei gilt folgende
@@ -183,9 +171,6 @@ public class DefaultMaterial extends LayerMaterial{
         double oldG = this.G;
         this.G = G;
         firePropertyChange(PROP_G, oldG, this.G);
-        if ((G != oldG) && (G < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterial.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert den Schubmoduls G<sub>||&perp;</sub> des Materials.
@@ -202,9 +187,6 @@ public class DefaultMaterial extends LayerMaterial{
         double oldG13 = this.G13;
         this.G13 = G13;
         firePropertyChange(PROP_G13, oldG13, this.G13);
-        if ((G13 != oldG13) && (G13 < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterial.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert die transversale Schubsteifigkeit G<sub>||&perp;</sub> des Materials.
@@ -221,9 +203,6 @@ public class DefaultMaterial extends LayerMaterial{
         double oldG23 = this.G23;
         this.G23 = G23;
         firePropertyChange(PROP_G23, oldG23, this.G23);
-        if ((G23 != oldG23) && (G23 < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(DefaultMaterial.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert die transversale Schubsteifigkeit G<sub>&perp;&perp;</sub> des Materials.

--- a/Micromechanics/src/de/elamx/micromechanics/Bundle.properties
+++ b/Micromechanics/src/de/elamx/micromechanics/Bundle.properties
@@ -1,4 +1,1 @@
 OpenIDE-Module-Name=Micromechanics
-Warning.negativeelasticmodulus=<html>A negative elastic modulus has been defined.<br>Please check your input.</html>
-Warning.negativeshearmodulus=<html>A negative shear modulus has been defined.<br>Please check your input.</html>
-Warning.negativepoissonratio=<html>A negative Poisson's ratio has been defined.<br>Please check your input.</html>

--- a/Micromechanics/src/de/elamx/micromechanics/Bundle_de.properties
+++ b/Micromechanics/src/de/elamx/micromechanics/Bundle_de.properties
@@ -1,4 +1,1 @@
 OpenIDE-Module-Name=Mikromechanik
-Warning.negativeelasticmodulus=<html>Es wurde ein negativer Elastizit\u00e4tsmodul definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>
-Warning.negativeshearmodulus=<html>Es wurde ein negativer Schubmodul definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>
-Warning.negativepoissonratio=<html>Es wurde eine negative Querkontraktionszahl definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>

--- a/Micromechanics/src/de/elamx/micromechanics/Fiber.java
+++ b/Micromechanics/src/de/elamx/micromechanics/Fiber.java
@@ -27,9 +27,6 @@ package de.elamx.micromechanics;
 
 import de.elamx.laminate.Material;
 import java.util.UUID;
-import org.openide.DialogDisplayer;
-import org.openide.NotifyDescriptor;
-import org.openide.util.NbBundle;
 
 /**
  *
@@ -108,9 +105,6 @@ public class Fiber extends Material{
         double oldEpar = this.Epar;
         this.Epar = Epar;
         firePropertyChange(PROP_EPAR, oldEpar, Epar);
-        if ((Epar != oldEpar) && (Epar < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(Fiber.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert den E-Modul in Faserrichtung E<sub>||</sub> des Materials.
@@ -127,9 +121,6 @@ public class Fiber extends Material{
         double oldEnor = this.Enor;
         this.Enor = Enor;
         firePropertyChange(PROP_ENOR, oldEnor, this.Enor);
-        if ((Enor != oldEnor) && (Enor < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(Fiber.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert den E-Modul quer zur Faserrichtung E<sub>&perp;</sub> des Materials.
@@ -148,9 +139,6 @@ public class Fiber extends Material{
         double oldNue12 = this.nue12;
         nue12 = nue;
         firePropertyChange(PROP_NUE12, oldNue12, nue12);
-        if ((nue12 != oldNue12) && (nue12 < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(Fiber.class, "Warning.negativepoissonratio"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert die Querkontraktionszahl &nu;<sub>12</sub> des Materials. Dabei gilt folgende
@@ -169,9 +157,6 @@ public class Fiber extends Material{
         double oldG = this.G;
         this.G = G;
         firePropertyChange(PROP_G, oldG, this.G);
-        if ((G != oldG) && (G < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(Fiber.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert den Schubmoduls G<sub>||&perp;</sub> des Materials.
@@ -188,9 +173,6 @@ public class Fiber extends Material{
         double oldG13 = this.G13;
         this.G13 = G13;
         firePropertyChange(PROP_G13, oldG13, this.G13);
-        if ((G13 != oldG13) && (G13 < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(Fiber.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert die transversale Schubsteifigkeit G<sub>||&perp;</sub> des Materials.
@@ -207,9 +189,6 @@ public class Fiber extends Material{
         double oldG23 = this.G23;
         this.G23 = G23;
         firePropertyChange(PROP_G23, oldG23, this.G23);
-        if ((G23 != oldG23) && (G23 < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(Fiber.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert die transversale Schubsteifigkeit G<sub>&perp;&perp;</sub> des Materials.

--- a/Micromechanics/src/de/elamx/micromechanics/Matrix.java
+++ b/Micromechanics/src/de/elamx/micromechanics/Matrix.java
@@ -27,9 +27,6 @@ package de.elamx.micromechanics;
 
 import de.elamx.laminate.Material;
 import java.util.UUID;
-import org.openide.DialogDisplayer;
-import org.openide.NotifyDescriptor;
-import org.openide.util.NbBundle;
 
 /**
  *
@@ -128,9 +125,6 @@ public class Matrix extends Material{
         double oldG = G;
         G = E / (2 * (1.0 + nue));
         firePropertyChange(PROP_G, oldG, G);
-        if ((nue != oldNue) && (nue < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(Matrix.class, "Warning.negativepoissonratio"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
 
     /**
@@ -145,9 +139,6 @@ public class Matrix extends Material{
         double oldG = G;
         G = E / (2 * (1.0 + nue));
         firePropertyChange(PROP_G, oldG, G);
-        if ((E != oldE) && (E < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(Matrix.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
 
     public double getE() {

--- a/Micromechanics/src/de/elamx/micromechanics/MicroMechanicMaterial.java
+++ b/Micromechanics/src/de/elamx/micromechanics/MicroMechanicMaterial.java
@@ -34,10 +34,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collection;
 import java.util.UUID;
-import org.openide.DialogDisplayer;
-import org.openide.NotifyDescriptor;
 import org.openide.util.Lookup;
-import org.openide.util.NbBundle;
 import org.openide.util.lookup.Lookups;
 
 /**
@@ -402,9 +399,6 @@ public class MicroMechanicMaterial extends LayerMaterial implements PropertyChan
         double oldEpar = this.Epar;
         this.Epar = Epar;
         firePropertyChange(PROP_EPAR, oldEpar, Epar);
-        if ((Epar != oldEpar) && (Epar < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterial.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
 
     /**
@@ -415,9 +409,6 @@ public class MicroMechanicMaterial extends LayerMaterial implements PropertyChan
         double oldEnor = this.Enor;
         this.Enor = Enor;
         firePropertyChange(PROP_ENOR, oldEnor, this.Enor);
-        if ((Enor != oldEnor) && (Enor < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterial.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
 
     /**
@@ -430,9 +421,6 @@ public class MicroMechanicMaterial extends LayerMaterial implements PropertyChan
         double oldNue12 = this.nue12;
         nue12 = nue;
         firePropertyChange(PROP_NUE12, oldNue12, nue12);
-        if ((nue != oldNue12) && (nue < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterial.class, "Warning.negativepoissonratio"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
 
     /**
@@ -443,9 +431,6 @@ public class MicroMechanicMaterial extends LayerMaterial implements PropertyChan
         double oldG = this.G;
         this.G = G;
         firePropertyChange(PROP_G, oldG, this.G);
-        if ((G != oldG) && (G < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterial.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
 
     /**
@@ -456,9 +441,6 @@ public class MicroMechanicMaterial extends LayerMaterial implements PropertyChan
         double oldG13 = this.G13;
         this.G13 = G13;
         firePropertyChange(PROP_G13, oldG13, this.G13);
-        if ((G13 != oldG13) && (G13 < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterial.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert die transversale Schubsteifigkeit G<sub>||&perp;</sub> des Materials.
@@ -475,9 +457,6 @@ public class MicroMechanicMaterial extends LayerMaterial implements PropertyChan
         double oldG23 = this.G23;
         this.G23 = G23;
         firePropertyChange(PROP_G23, oldG23, this.G23);
-        if ((G23 != oldG23) && (G23 < 0.)) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterial.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
-        }
     }
     /**
      * Liefert die transversale Schubsteifigkeit G<sub>&perp;&perp;</sub> des Materials.

--- a/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/Bundle.properties
+++ b/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/Bundle.properties
@@ -143,3 +143,7 @@ MicroMechanicMaterialNode.SHEARMODULUS13.html=<html>G<sub>T,||&perp</sub></html>
 MicroMechanicMaterialNode.SHEARMODULUS23.description=<html>Transversal shear modulus of the Layer [N/mm<sup>2</sup>]</html>
 MicroMechanicMaterialNode.SHEARMODULUS23=Transversal Shear Modulus
 MicroMechanicMaterialNode.SHEARMODULUS23.html=<html>G<sub>T,&perp&perp</sub></html>
+
+Warning.negativeelasticmodulus=<html>A negative elastic modulus has been defined.<br>Please check your input.</html>
+Warning.negativeshearmodulus=<html>A negative shear modulus has been defined.<br>Please check your input.</html>
+Warning.negativepoissonratio=<html>A negative Poisson's ratio has been defined.<br>Please check your input.</html>

--- a/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/Bundle_de.properties
+++ b/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/Bundle_de.properties
@@ -91,3 +91,7 @@ MicroMechanicMaterialNode.SHEARMODULUS13.description=<html>transversaler Schubmo
 MicroMechanicMaterialNode.SHEARMODULUS23.description=<html>transversaler Schubmodul der Schicht [N/mm<sup>2</sup>]</html>
 MicroMechanicMaterialNode.SHEARMODULUS13=transversaler Schubmodul
 MicroMechanicMaterialNode.SHEARMODULUS23=transversaler Schubmodul
+
+Warning.negativeelasticmodulus=<html>Es wurde ein negativer Elastizit\u00e4tsmodul definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>
+Warning.negativeshearmodulus=<html>Es wurde ein negativer Schubmodul definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>
+Warning.negativepoissonratio=<html>Es wurde eine negative Querkontraktionszahl definiert.<br>Bitte pr\u00fcfen Sie Ihre Eingabe.</html>

--- a/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/FibreNode.java
+++ b/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/FibreNode.java
@@ -42,6 +42,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import javax.swing.Action;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.awt.Actions;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
@@ -190,6 +192,21 @@ public class FibreNode extends AbstractNode implements PropertyChangeListener {
         if (evt.getPropertyName().equals(Material.PROP_NAME)) {
             this.fireDisplayNameChange((String)evt.getOldValue(), (String)evt.getNewValue());
             return;
+        }
+        if (evt.getPropertyName().equals(Fiber.PROP_EPAR) || evt.getPropertyName().equals(Fiber.PROP_ENOR))  {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(FibreNode.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
+            }
+        }
+        if (evt.getPropertyName().equals(Fiber.PROP_NUE12)) {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(FibreNode.class, "Warning.negativepoissonratio"), NotifyDescriptor.WARNING_MESSAGE));
+            }
+        }
+        if (evt.getPropertyName().equals(Fiber.PROP_G) || evt.getPropertyName().equals(Fiber.PROP_G13) || evt.getPropertyName().equals(Fiber.PROP_G23)) {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(FibreNode.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
+            }
         }
         this.firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
     }

--- a/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/MatrixNode.java
+++ b/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/MatrixNode.java
@@ -42,6 +42,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import javax.swing.Action;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.awt.Actions;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
@@ -167,6 +169,16 @@ public class MatrixNode extends AbstractNode implements PropertyChangeListener {
         if (evt.getPropertyName().equals(Material.PROP_NAME)) {
             this.fireDisplayNameChange((String)evt.getOldValue(), (String)evt.getNewValue());
             return;
+        }
+        if (evt.getPropertyName().equals(Matrix.PROP_E))  {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MatrixNode.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
+            }
+        }
+        if (evt.getPropertyName().equals(Matrix.PROP_NUE)) {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MatrixNode.class, "Warning.negativepoissonratio"), NotifyDescriptor.WARNING_MESSAGE));
+            }
         }
         this.firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
     }

--- a/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/MicroMechanicMaterialNode.java
+++ b/MicromechanicsUI/src/de/elamx/micromechanicsui/nodes/MicroMechanicMaterialNode.java
@@ -53,6 +53,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import javax.swing.Action;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.awt.Actions;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
@@ -322,6 +324,21 @@ public class MicroMechanicMaterialNode extends AbstractNode implements PropertyC
         if (evt.getPropertyName().equals(Material.PROP_NAME)) {
             this.fireDisplayNameChange((String)evt.getOldValue(), (String)evt.getNewValue());
             return;
+        }
+        if (evt.getPropertyName().equals(MicroMechanicMaterial.PROP_EPAR) || evt.getPropertyName().equals(MicroMechanicMaterial.PROP_ENOR))  {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterialNode.class, "Warning.negativeelasticmodulus"), NotifyDescriptor.WARNING_MESSAGE));
+            }
+        }
+        if (evt.getPropertyName().equals(MicroMechanicMaterial.PROP_NUE12)) {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterialNode.class, "Warning.negativepoissonratio"), NotifyDescriptor.WARNING_MESSAGE));
+            }
+        }
+        if (evt.getPropertyName().equals(MicroMechanicMaterial.PROP_G) || evt.getPropertyName().equals(MicroMechanicMaterial.PROP_G13) || evt.getPropertyName().equals(MicroMechanicMaterial.PROP_G23)) {
+            if (((double)evt.getNewValue() != (double)evt.getOldValue()) && ((double)evt.getNewValue() < 0.)) {
+                DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(NbBundle.getMessage(MicroMechanicMaterialNode.class, "Warning.negativeshearmodulus"), NotifyDescriptor.WARNING_MESSAGE));
+            }
         }
         this.firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
     }


### PR DESCRIPTION
+ Warnungen bei Definition negativer Steifigkeiten (Elastizitäts- und Schubmoduln) sowie negativer Querkontraktionszahlen in GUI-Modul verschoben;