### PR TITLE
Fix für Rohdatenexport der KLT-Matrizen

### DIFF
--- a/Classical_Laminated_Plate_Theory_UI/src/de/elamx/clt/calculation/polar/CLT_PolarChartTopComponent.java
+++ b/Classical_Laminated_Plate_Theory_UI/src/de/elamx/clt/calculation/polar/CLT_PolarChartTopComponent.java
@@ -512,7 +512,7 @@ public final class CLT_PolarChartTopComponent extends TopComponent implements Lo
         public void export(FileWriter fw) {
             try {
                 String ls = System.getProperty("line.separator");
-                String[] caption = new String[]{"A11", "A12", "A22", "A66"};
+                String[] caption = new String[]{"A11", "A12", "A22", "A66", "B11", "B12", "B22", "B66", "D11", "D12", "D22", "D66"};
                 fw.write("Angle");
                 for (int ii = 0; ii < showATerm.length; ii++) {
                     if (showATerm[ii]) {


### PR DESCRIPTION
Hallo,
beim Rohdatenexport von Polardiagrammen ist mir ein Problem aufgefallen, wenn Einträge der B- und D-Matrix ausgewählt sind.
Das lässt sich mit der vorgeschlagenen Ergänzung anscheinend schon lösen. Ich hoffe, sie ist sonst kompatibel.